### PR TITLE
Adding isArray check before chart is instantiated.

### DIFF
--- a/angular-chartjs-doughnut-directive.js
+++ b/angular-chartjs-doughnut-directive.js
@@ -53,12 +53,14 @@ angular.module('angular.directives-chartjs-doughnut', []).directive('angChartjsD
         pre: function preLink(scope, instanceElement, instanceAttributes, controller) {
           var expression = canvas.getAttribute('data-chartjs-model');
           scope.$watch(expression, function (newValue, oldValue) {
-            var callback = scope[node.getAttribute('data-chartjs-on-animation-complete')];
-            if (callback !== undefined) {
-              options.onAnimationComplete = callback;
-            }
+            if (angular.isArray(newValue)){
+              var callback = scope[node.getAttribute('data-chartjs-on-animation-complete')];
+              if (callback !== undefined) {
+                options.onAnimationComplete = callback;
+              }
 
-            chart.Doughnut(newValue, options);
+              chart.Doughnut(newValue, options);
+            }
           }, true);
         },
         post: function postLink(scope, instanceElement, instanceAttributes, controller) {}


### PR DESCRIPTION
This prevents an error in Chart.js when instantiating the chart with undefined data or data of the wrong type. The Angular $watch method may also pass a newValue of undefined when it is first called. Thanks for building this directive. Good work! :)
